### PR TITLE
Add pruning capability

### DIFF
--- a/lektor_index_pages/buildprog.py
+++ b/lektor_index_pages/buildprog.py
@@ -29,13 +29,13 @@ class IndexBuildProgram(BuildProgram):
         config_filename = self.source.datamodel.filename
         template = self.source._data['_template']
 
-        if config_filename is not None:
-            ctx = get_ctx()
-            if ctx is not None:
+        ctx = get_ctx()
+        if ctx is not None:
+            # for pruning we need the vpath url, so track self.source
+            ctx.record_virtual_dependency(self.source)
+            if config_filename is not None:
                 ctx.record_dependency(config_filename)
 
-        # for pruning we need the vpath url, so track self.source
-        self.source.pad.db.track_record_dependency(self.source)
         artifact.render_template_into(template, this=self.source)
 
     def iter_child_sources(self):

--- a/lektor_index_pages/buildprog.py
+++ b/lektor_index_pages/buildprog.py
@@ -3,6 +3,7 @@
 
 from lektor.build_programs import BuildProgram
 from lektor.context import get_ctx
+from .pruner import track_not_prune
 
 
 class IndexBuildProgram(BuildProgram):
@@ -22,6 +23,7 @@ class IndexBuildProgram(BuildProgram):
                 # immediately after the build.  I guess this will do.
                 sources = [record.source_filename]
                 self.declare_artifact(artifact_name, sources=sources)
+                track_not_prune(artifact_name)
 
     def build_artifact(self, artifact):
         config_filename = self.source.datamodel.filename
@@ -32,6 +34,8 @@ class IndexBuildProgram(BuildProgram):
             if ctx is not None:
                 ctx.record_dependency(config_filename)
 
+        # for pruning we need the vpath url, so track self.source
+        self.source.pad.db.track_record_dependency(self.source)
         artifact.render_template_into(template, this=self.source)
 
     def iter_child_sources(self):

--- a/lektor_index_pages/plugin.py
+++ b/lektor_index_pages/plugin.py
@@ -17,6 +17,7 @@ from .config import (
     )
 from .indexmodel import VIRTUAL_PATH_PREFIX
 from .sourceobj import IndexBase
+from .pruner import prune
 
 
 class Cache:
@@ -74,6 +75,9 @@ class IndexPagesPlugin(Plugin):
 
     def on_before_build_all(self, builder, **extra):
         self.cache.clear()
+
+    def on_after_prune(self, builder, all, **extra):
+        prune(builder, '@' + VIRTUAL_PATH_PREFIX)
 
     def on_setup_env(self, extra_flags=None, **extra):
         env = self.env

--- a/lektor_index_pages/pruner.py
+++ b/lektor_index_pages/pruner.py
@@ -1,0 +1,38 @@
+'''
+Static collector for build-artifact urls.
+All non-tracked VPATH-urls will be pruned after build.
+'''
+from lektor.builder import Builder
+from lektor.reporter import reporter
+from lektor.utils import prune_file_and_folder
+
+_cache = set()
+# Note: this var is static or otherwise two instances of
+#       this module would prune each others artifacts.
+
+
+def track_not_prune(url: str) -> None:
+    ''' Add url to build cache to prevent pruning. '''
+    _cache.add(url.lstrip('/'))
+
+
+def prune(builder: Builder, vpath: str) -> None:
+    ''' Remove previously generated, unreferenced Artifacts. '''
+    dest_path = builder.destination_path
+    con = builder.connect_to_database()
+    try:
+        with builder.new_build_state() as build_state:
+            for url, file in build_state.iter_artifacts():
+                if url.lstrip('/') in _cache:
+                    continue  # generated in this build-run
+                infos = build_state.get_artifact_dependency_infos(url, [])
+                for artifact_name, _ in infos:
+                    if vpath not in artifact_name:
+                        continue  # we only care about our Virtuals
+                    reporter.report_pruned_artifact(url)
+                    prune_file_and_folder(file.filename, dest_path)
+                    build_state.remove_artifact(url)
+                    break  # there is only one VPATH-entry per source
+    finally:
+        con.close()
+    _cache.clear()


### PR DESCRIPTION
This PR adds a prune of old virtual objects at the end of the build process.
The prune is achieved by iterating over all artifacts stored in the database and deleting those that were not generated during this build.